### PR TITLE
Ignore has_one :through associations

### DIFF
--- a/lib/consistency_fail/introspectors/has_one.rb
+++ b/lib/consistency_fail/introspectors/has_one.rb
@@ -5,7 +5,7 @@ module ConsistencyFail
     class HasOne
       def instances(model)
         model.reflect_on_all_associations.select do |a|
-          a.macro == :has_one && a.options[:as].to_s.length == 0
+          a.macro == :has_one && a.options[:as].to_s.length == 0 && a.options[:through].to_s.length == 0
         end
       end
 

--- a/spec/introspectors/has_one_spec.rb
+++ b/spec/introspectors/has_one_spec.rb
@@ -38,6 +38,14 @@ describe ConsistencyFail::Introspectors::HasOne do
 
       subject.instances(model).should == []
     end
+
+    it "finds one, but it's a :through association" do
+      model = fake_ar_model("User")
+      association = double("association", :macro => :has_one, :options => {:through => :amodel})
+      model.stub!(:reflect_on_all_associations).and_return([association])
+
+      subject.instances(model).should == []
+    end
   end
 
   describe "finding missing indexes" do


### PR DESCRIPTION
The unique indexes should be enforced on the referenced table
