### PR TITLE
Use AssociationReflection#klass rather than constantizing the #class_name

### DIFF
--- a/lib/consistency_fail/introspectors/has_one.rb
+++ b/lib/consistency_fail/introspectors/has_one.rb
@@ -17,7 +17,7 @@ module ConsistencyFail
           else
             foreign_key = a.primary_key_name
           end
-          ConsistencyFail::Index.new(a.class_name.constantize,
+          ConsistencyFail::Index.new(a.klass,
                                      a.table_name.to_s,
                                      [foreign_key])
         end.compact

--- a/lib/consistency_fail/introspectors/polymorphic.rb
+++ b/lib/consistency_fail/introspectors/polymorphic.rb
@@ -16,7 +16,7 @@ module ConsistencyFail
           as_id   = "#{as}_id"
 
           ConsistencyFail::Index.new(
-            a.class_name.constantize,
+            a.klass,
             a.table_name.to_s,
             [as_type, as_id]
           )

--- a/lib/consistency_fail/models.rb
+++ b/lib/consistency_fail/models.rb
@@ -26,6 +26,5 @@ module ConsistencyFail
     def all
       ActiveRecord::Base.send(:descendants).sort_by(&:name)
     end
-
   end
 end

--- a/spec/introspectors/has_one_spec.rb
+++ b/spec/introspectors/has_one_spec.rb
@@ -57,11 +57,10 @@ describe ConsistencyFail::Introspectors::HasOne do
                                      :reflect_on_all_associations => [@association])
       @address_class = double("Address Class")
       @address_string = "Address"
-      allow(@address_string).to receive(:constantize).and_return(@address_class)
     end
 
     it "finds one" do
-      allow(@association).to receive_messages(:table_name => :addresses, :class_name => @address_string, :foreign_key => "user_id")
+      allow(@association).to receive_messages(:table_name => :addresses, :klass => @address_class, :foreign_key => "user_id")
       allow(@address_class).to receive_message_chain(:connection, :indexes).with("addresses").and_return([])
 
       indexes = subject.missing_indexes(@model)
@@ -69,7 +68,7 @@ describe ConsistencyFail::Introspectors::HasOne do
     end
 
     it "finds one in Rails 3.0.x (where foreign_key is not defined)" do
-      allow(@association).to receive_messages(:table_name => :addresses, :class_name => @address_string, :primary_key_name => "user_id")
+      allow(@association).to receive_messages(:table_name => :addresses, :klass => @address_class, :primary_key_name => "user_id")
       allow(@address_class).to receive_message_chain(:connection, :indexes).with("addresses").and_return([])
 
       indexes = subject.missing_indexes(@model)
@@ -77,7 +76,7 @@ describe ConsistencyFail::Introspectors::HasOne do
     end
 
     it "finds none when they're already in place" do
-      allow(@association).to receive_messages(:table_name => :addresses, :class_name => @address_string, :foreign_key => "user_id")
+      allow(@association).to receive_messages(:table_name => :addresses, :klass => @address_class, :foreign_key => "user_id")
       index = ConsistencyFail::Index.new(double('model'), "addresses", ["user_id"])
 
       fake_connection = double("connection")
@@ -89,8 +88,5 @@ describe ConsistencyFail::Introspectors::HasOne do
 
       expect(subject.missing_indexes(@model)).to eq([])
     end
-
   end
 end
-
-

--- a/spec/introspectors/polymorphic_spec.rb
+++ b/spec/introspectors/polymorphic_spec.rb
@@ -49,11 +49,10 @@ describe ConsistencyFail::Introspectors::Polymorphic do
                                      :reflect_on_all_associations => [@association])
       @address_class = double("Address Class")
       @address_string = "Address"
-      allow(@address_string).to receive(:constantize).and_return(@address_class)
     end
 
     it "finds one" do
-      allow(@association).to receive_messages(:table_name => :addresses, :class_name => @address_string)
+      allow(@association).to receive_messages(:table_name => :addresses, :klass => @address_class)
       allow(@address_class).to receive_message_chain(:connection, :indexes).with("addresses").and_return([])
 
       indexes = subject.missing_indexes(@model)
@@ -61,7 +60,7 @@ describe ConsistencyFail::Introspectors::Polymorphic do
     end
 
     it "finds none when they're already in place" do
-      allow(@association).to receive_messages(:table_name => :addresses, :class_name => @address_string)
+      allow(@association).to receive_messages(:table_name => :addresses, :klass => @address_class)
       index = ConsistencyFail::Index.new(double('model'), "addresses", ["addressable_type", "addressable_id"])
 
       fake_connection = double("connection")


### PR DESCRIPTION
This fixes a small bug that appears when using namespaced model names.. Something like this:

```ruby
class Foo < ActiveRecord::Base
  has_one :bar
end
```
in app/models/foo.rb and
```ruby
class Foo::Bar < ActiveRecord::Base
end
```
in app/models/foo/bar.rb (with table name foo_bars).

That will work just fine in Rails, but the current code on master will raise a NameError exception because it tries to constantize "Bar" (rather than "Foo::Bar"). This PR fixes that by using the [AssociationReflection#klass](http://www.rubydoc.info/docs/rails/3.0.0/ActiveRecord/Reflection/AssociationReflection#klass-instance_method) rather than #constantize on #class_name, which is already smart enough to find the right class.

I didn't add any tests yet because the tests (on master) don't pass for me locally.. Are they supposed to?

@trptcolin, please take a quick look