### PR TITLE
Convert rspec syntax to latest version

### DIFF
--- a/spec/index_spec.rb
+++ b/spec/index_spec.rb
@@ -7,31 +7,34 @@ describe ConsistencyFail::Index do
     it "holds onto model, table name, and columns" do
       model = double("model")
       index = ConsistencyFail::Index.new(model, "addresses", ["city", "state"])
-      index.model.should == model
-      index.table_name.should == "addresses"
-      index.columns.should == ["city", "state"]
+      expect(index.model).to eq(model)
+      expect(index.table_name).to eq("addresses")
+      expect(index.columns).to eq(["city", "state"])
     end
 
     it "leaves columns in the initial order (since we only care about presence, not performance)" do
       index = ConsistencyFail::Index.new(double('model'), "addresses", ["state", "city"])
-      index.columns.should == ["state", "city"]
+      expect(index.columns).to eq(["state", "city"])
     end
   end
 
   describe "equality test" do
     it "passes when everything matches" do
-      ConsistencyFail::Index.new(double('model'), "addresses", ["city", "state"]).should ==
+      expect(ConsistencyFail::Index.new(double('model'), "addresses", ["city", "state"])).to eq(
         ConsistencyFail::Index.new(double('model'),"addresses", ["city", "state"])
+      )
     end
 
     it "fails when tables are different" do
-      ConsistencyFail::Index.new(double('model'),"locations", ["city", "state"]).should_not ==
+      expect(ConsistencyFail::Index.new(double('model'),"locations", ["city", "state"])).not_to eq(
         ConsistencyFail::Index.new(double('model'),"addresses", ["city", "state"])
+      )
     end
 
     it "fails when columns are different" do
-      ConsistencyFail::Index.new(double('model'),"addresses", ["city", "state"]).should_not ==
+      expect(ConsistencyFail::Index.new(double('model'),"addresses", ["city", "state"])).not_to eq(
         ConsistencyFail::Index.new(double('model'),"addresses", ["state", "zip"])
+      )
     end
   end
 end

--- a/spec/introspectors/has_one_spec.rb
+++ b/spec/introspectors/has_one_spec.rb
@@ -10,41 +10,41 @@ describe ConsistencyFail::Introspectors::HasOne do
   describe "instances of has_one" do
     it "finds none" do
       model = fake_ar_model("User")
-      model.stub(:reflect_on_all_associations).and_return([])
+      allow(model).to receive(:reflect_on_all_associations).and_return([])
 
-      subject.instances(model).should == []
+      expect(subject.instances(model)).to eq([])
     end
 
     it "finds one" do
       model = fake_ar_model("User")
       association = double("association", :macro => :has_one, :options => {})
-      model.stub!(:reflect_on_all_associations).and_return([association])
+      allow(model).to receive(:reflect_on_all_associations).and_return([association])
 
-      subject.instances(model).should == [association]
+      expect(subject.instances(model)).to eq([association])
     end
 
     it "finds other associations, but not has_one" do
       model = fake_ar_model("User")
       validation = double("validation", :macro => :has_many)
-      model.stub!(:reflect_on_all_associations).and_return([validation])
+      allow(model).to receive(:reflect_on_all_associations).and_return([validation])
 
-      subject.instances(model).should == []
+      expect(subject.instances(model)).to eq([])
     end
 
     it "finds one, but it's a polymorphic association" do
       model = fake_ar_model("User")
       association = double("association", :macro => :has_one, :options => {:as => "addressable"})
-      model.stub!(:reflect_on_all_associations).and_return([association])
+      allow(model).to receive(:reflect_on_all_associations).and_return([association])
 
-      subject.instances(model).should == []
+      expect(subject.instances(model)).to eq([])
     end
 
     it "finds one, but it's a :through association" do
       model = fake_ar_model("User")
       association = double("association", :macro => :has_one, :options => {:through => :amodel})
-      model.stub!(:reflect_on_all_associations).and_return([association])
+      allow(model).to receive(:reflect_on_all_associations).and_return([association])
 
-      subject.instances(model).should == []
+      expect(subject.instances(model)).to eq([])
     end
   end
 
@@ -57,37 +57,37 @@ describe ConsistencyFail::Introspectors::HasOne do
                                      :reflect_on_all_associations => [@association])
       @address_class = double("Address Class")
       @address_string = "Address"
-      @address_string.stub(:constantize).and_return(@address_class)
+      allow(@address_string).to receive(:constantize).and_return(@address_class)
     end
 
     it "finds one" do
-      @association.stub!(:table_name => :addresses, :class_name => @address_string, :foreign_key => "user_id")
-      @address_class.stub_chain(:connection, :indexes).with("addresses").and_return([])
+      allow(@association).to receive_messages(:table_name => :addresses, :class_name => @address_string, :foreign_key => "user_id")
+      allow(@address_class).to receive_message_chain(:connection, :indexes).with("addresses").and_return([])
 
       indexes = subject.missing_indexes(@model)
-      indexes.should == [ConsistencyFail::Index.new(fake_ar_model("Address"), "addresses", ["user_id"])]
+      expect(indexes).to eq([ConsistencyFail::Index.new(fake_ar_model("Address"), "addresses", ["user_id"])])
     end
 
     it "finds one in Rails 3.0.x (where foreign_key is not defined)" do
-      @association.stub!(:table_name => :addresses, :class_name => @address_string, :primary_key_name => "user_id")
-      @address_class.stub_chain(:connection, :indexes).with("addresses").and_return([])
+      allow(@association).to receive_messages(:table_name => :addresses, :class_name => @address_string, :primary_key_name => "user_id")
+      allow(@address_class).to receive_message_chain(:connection, :indexes).with("addresses").and_return([])
 
       indexes = subject.missing_indexes(@model)
-      indexes.should == [ConsistencyFail::Index.new(fake_ar_model("Address"), "addresses", ["user_id"])]
+      expect(indexes).to eq([ConsistencyFail::Index.new(fake_ar_model("Address"), "addresses", ["user_id"])])
     end
 
     it "finds none when they're already in place" do
-      @association.stub!(:table_name => :addresses, :class_name => @address_string, :foreign_key => "user_id")
+      allow(@association).to receive_messages(:table_name => :addresses, :class_name => @address_string, :foreign_key => "user_id")
       index = ConsistencyFail::Index.new(double('model'), "addresses", ["user_id"])
 
       fake_connection = double("connection")
-      @address_class.stub_chain(:connection).and_return(fake_connection)
+      allow(@address_class).to receive_message_chain(:connection).and_return(fake_connection)
 
-      ConsistencyFail::Introspectors::TableData.stub_chain(:new, :unique_indexes_by_table).
+      allow(ConsistencyFail::Introspectors::TableData).to receive_message_chain(:new, :unique_indexes_by_table).
         with(@address_class, fake_connection, "addresses").
         and_return([index])
 
-      subject.missing_indexes(@model).should == []
+      expect(subject.missing_indexes(@model)).to eq([])
     end
 
   end

--- a/spec/introspectors/polymorphic_spec.rb
+++ b/spec/introspectors/polymorphic_spec.rb
@@ -10,33 +10,33 @@ describe ConsistencyFail::Introspectors::Polymorphic do
   describe "instances of polymorphic" do
     it "finds none" do
       model = fake_ar_model("User")
-      model.stub(:reflect_on_all_associations).and_return([])
+      allow(model).to receive(:reflect_on_all_associations).and_return([])
 
-      subject.instances(model).should == []
+      expect(subject.instances(model)).to eq([])
     end
 
     it "finds one" do
       model = fake_ar_model("User")
       association = double("association", :macro => :has_one, :options => {:as => "addressable"})
-      model.stub!(:reflect_on_all_associations).and_return([association])
+      allow(model).to receive(:reflect_on_all_associations).and_return([association])
 
-      subject.instances(model).should == [association]
+      expect(subject.instances(model)).to eq([association])
     end
 
     it "finds other has_one associations, but not polymorphic" do
       model = fake_ar_model("User")
       validation = double("association", :macro => :has_one, :options => {})
-      model.stub!(:reflect_on_all_associations).and_return([validation])
+      allow(model).to receive(:reflect_on_all_associations).and_return([validation])
 
-      subject.instances(model).should == []
+      expect(subject.instances(model)).to eq([])
     end
 
     it "finds other non has_one associations" do
       model = fake_ar_model("User")
       validation = double("association", :macro => :has_many)
-      model.stub!(:reflect_on_all_associations).and_return([validation])
+      allow(model).to receive(:reflect_on_all_associations).and_return([validation])
 
-      subject.instances(model).should == []
+      expect(subject.instances(model)).to eq([])
     end
   end
 
@@ -49,29 +49,29 @@ describe ConsistencyFail::Introspectors::Polymorphic do
                                      :reflect_on_all_associations => [@association])
       @address_class = double("Address Class")
       @address_string = "Address"
-      @address_string.stub(:constantize).and_return(@address_class)
+      allow(@address_string).to receive(:constantize).and_return(@address_class)
     end
 
     it "finds one" do
-      @association.stub!(:table_name => :addresses, :class_name => @address_string)
-      @address_class.stub_chain(:connection, :indexes).with("addresses").and_return([])
+      allow(@association).to receive_messages(:table_name => :addresses, :class_name => @address_string)
+      allow(@address_class).to receive_message_chain(:connection, :indexes).with("addresses").and_return([])
 
       indexes = subject.missing_indexes(@model)
-      indexes.should == [ConsistencyFail::Index.new(fake_ar_model("Address"), "addresses", ["addressable_type", "addressable_id"])]
+      expect(indexes).to eq([ConsistencyFail::Index.new(fake_ar_model("Address"), "addresses", ["addressable_type", "addressable_id"])])
     end
 
     it "finds none when they're already in place" do
-      @association.stub!(:table_name => :addresses, :class_name => @address_string)
+      allow(@association).to receive_messages(:table_name => :addresses, :class_name => @address_string)
       index = ConsistencyFail::Index.new(double('model'), "addresses", ["addressable_type", "addressable_id"])
 
       fake_connection = double("connection")
-      @address_class.stub_chain(:connection).and_return(fake_connection)
+      allow(@address_class).to receive_message_chain(:connection).and_return(fake_connection)
 
-      ConsistencyFail::Introspectors::TableData.stub_chain(:new, :unique_indexes_by_table).
+      allow(ConsistencyFail::Introspectors::TableData).to receive_message_chain(:new, :unique_indexes_by_table).
         with(@address_class, fake_connection, "addresses").
         and_return([index])
 
-      subject.missing_indexes(@model).should == []
+      expect(subject.missing_indexes(@model)).to eq([])
     end
   end
 end

--- a/spec/introspectors/table_data_spec.rb
+++ b/spec/introspectors/table_data_spec.rb
@@ -6,45 +6,45 @@ describe ConsistencyFail::Introspectors::TableData do
     it "finds none when the table does not exist" do
       model = fake_ar_model("User", :table_exists? => false)
 
-      subject.unique_indexes(model).should == []
+      expect(subject.unique_indexes(model)).to eq([])
     end
 
     it "gets one" do
       model = fake_ar_model("User", :table_exists? => true,
                                     :table_name => "users")
 
-      model.stub_chain(:connection, :indexes).
+      allow(model).to receive_message_chain(:connection, :indexes).
             with("users").
             and_return([fake_index_on(["a"], :unique => true)])
 
       indexes = subject.unique_indexes(model)
-      indexes.should == [ConsistencyFail::Index.new(double('model'), "users", ["a"])]
+      expect(indexes).to eq([ConsistencyFail::Index.new(double('model'), "users", ["a"])])
     end
 
     it "doesn't get non-unique indexes" do
       model = fake_ar_model("User", :table_exists? => true,
                                     :table_name => "users")
 
-      model.stub_chain(:connection, :indexes).
+      allow(model).to receive_message_chain(:connection, :indexes).
             with("users").
             and_return([fake_index_on(["a"], :unique => false)])
 
-      subject.unique_indexes(model).should == []
+      expect(subject.unique_indexes(model)).to eq([])
     end
 
     it "gets multiple unique indexes" do
       model = fake_ar_model("User", :table_exists? => true,
                                     :table_name => "users")
 
-      model.stub_chain(:connection, :indexes).
+      allow(model).to receive_message_chain(:connection, :indexes).
             with("users").
             and_return([fake_index_on(["a"], :unique => true),
                         fake_index_on(["b", "c"], :unique => true)])
 
       indexes = subject.unique_indexes(model)
-      indexes.size.should == 2
-      indexes.should == [ConsistencyFail::Index.new(double('model'), "users", ["a"]),
-                         ConsistencyFail::Index.new(double('model'), "users", ["b", "c"])]
+      expect(indexes.size).to eq(2)
+      expect(indexes).to eq([ConsistencyFail::Index.new(double('model'), "users", ["a"]),
+                         ConsistencyFail::Index.new(double('model'), "users", ["b", "c"])])
     end
   end
 

--- a/spec/introspectors/validates_uniqueness_of_spec.rb
+++ b/spec/introspectors/validates_uniqueness_of_spec.rb
@@ -9,25 +9,25 @@ describe ConsistencyFail::Introspectors::ValidatesUniquenessOf do
   describe "instances of validates_uniqueness_of" do
     it "finds none" do
       model = fake_ar_model("User")
-      model.stub!(:validators).and_return([])
+      allow(model).to receive(:validators).and_return([])
 
-      subject.instances(model).should == []
+      expect(subject.instances(model)).to eq([])
     end
 
     it "finds one" do
       model = fake_ar_model("User")
       validation = double("validation", :class => ActiveRecord::Validations::UniquenessValidator)
-      model.stub!(:validators).and_return([validation])
+      allow(model).to receive(:validators).and_return([validation])
 
-      subject.instances(model).should == [validation]
+      expect(subject.instances(model)).to eq([validation])
     end
 
     it "finds other validations, but not uniqueness" do
       model = fake_ar_model("User")
       validation = double("validation", :class => ActiveModel::Validations::FormatValidator)
-      model.stub!(:validators).and_return([validation])
+      allow(model).to receive(:validators).and_return([validation])
 
-      subject.instances(model).should == []
+      expect(subject.instances(model)).to eq([])
     end
   end
 
@@ -40,54 +40,54 @@ describe ConsistencyFail::Introspectors::ValidatesUniquenessOf do
     end
 
     it "finds one" do
-      @validation.stub!(:attributes => [:email], :options => {})
-      @model.stub_chain(:connection, :indexes).with("users").and_return([])
+      allow(@validation).to receive_messages(:attributes => [:email], :options => {})
+      allow(@model).to receive_message_chain(:connection, :indexes).with("users").and_return([])
 
       indexes = subject.missing_indexes(@model)
-      indexes.should == [ConsistencyFail::Index.new(double('model'), "users", ["email"])]
+      expect(indexes).to eq([ConsistencyFail::Index.new(double('model'), "users", ["email"])])
     end
 
     it "finds one where the validation has scoped columns" do
-      @validation.stub!(:attributes => [:city], :options => {:scope => [:email, :state]})
-      @model.stub_chain(:connection, :indexes).with("users").and_return([])
+      allow(@validation).to receive_messages(:attributes => [:city], :options => {:scope => [:email, :state]})
+      allow(@model).to receive_message_chain(:connection, :indexes).with("users").and_return([])
 
       indexes = subject.missing_indexes(@model)
-      indexes.should == [ConsistencyFail::Index.new(double('model'), "users", ["city", "email", "state"])]
+      expect(indexes).to eq([ConsistencyFail::Index.new(double('model'), "users", ["city", "email", "state"])])
     end
 
     it "leaves the columns in the given order" do
-      @validation.stub!(:attributes => [:email], :options => {:scope => [:city, :state]})
-      @model.stub_chain(:connection, :indexes).with("users").and_return([])
+      allow(@validation).to receive_messages(:attributes => [:email], :options => {:scope => [:city, :state]})
+      allow(@model).to receive_message_chain(:connection, :indexes).with("users").and_return([])
 
       indexes = subject.missing_indexes(@model)
-      indexes.should == [ConsistencyFail::Index.new(double('model'), "users", ["email", "city", "state"])]
+      expect(indexes).to eq([ConsistencyFail::Index.new(double('model'), "users", ["email", "city", "state"])])
     end
 
     it "finds two where there are multiple attributes" do
-      @validation.stub!(:attributes => [:email, :name], :options => {:scope => [:city, :state]})
-      @model.stub_chain(:connection, :indexes).with("users").and_return([])
+      allow(@validation).to receive_messages(:attributes => [:email, :name], :options => {:scope => [:city, :state]})
+      allow(@model).to receive_message_chain(:connection, :indexes).with("users").and_return([])
 
       indexes = subject.missing_indexes(@model)
-      indexes.should == [ConsistencyFail::Index.new(double('model'), "users", ["email", "city", "state"]),
-                         ConsistencyFail::Index.new(double('model'), "users", ["name", "city", "state"])]
+      expect(indexes).to eq([ConsistencyFail::Index.new(double('model'), "users", ["email", "city", "state"]),
+                         ConsistencyFail::Index.new(double('model'), "users", ["name", "city", "state"])])
     end
 
     it "finds none when they're already in place" do
-      @validation.stub!(:attributes => [:email], :options => {})
+      allow(@validation).to receive_messages(:attributes => [:email], :options => {})
       index = fake_index_on(["email"], :unique => true)
-      @model.stub_chain(:connection, :indexes).with("users").
+      allow(@model).to receive_message_chain(:connection, :indexes).with("users").
              and_return([index])
 
-      subject.missing_indexes(@model).should == []
+      expect(subject.missing_indexes(@model)).to eq([])
     end
 
     it "finds none when indexes are there but in a different order" do
-      @validation.stub!(:attributes => [:email], :options => {:scope => [:city, :state]})
+      allow(@validation).to receive_messages(:attributes => [:email], :options => {:scope => [:city, :state]})
       index = fake_index_on(["state", "email", "city"], :unique => true)
-      @model.stub_chain(:connection, :indexes).with("users").
+      allow(@model).to receive_message_chain(:connection, :indexes).with("users").
              and_return([index])
 
-      subject.missing_indexes(@model).should == []
+      expect(subject.missing_indexes(@model)).to eq([])
     end
   end
 end

--- a/spec/models_spec.rb
+++ b/spec/models_spec.rb
@@ -7,32 +7,32 @@ describe ConsistencyFail::Models do
   end
 
   it "gets the load path" do
-    models([:a, :b, :c]).load_path.should == [:a, :b, :c]
+    expect(models([:a, :b, :c]).load_path).to eq([:a, :b, :c])
   end
 
   it "gets the directories matching /models/" do
     models = models(["foo/bar/baz", "app/models", "some/other/models"])
-    models.dirs.should == ["app/models", "some/other/models"]
+    expect(models.dirs).to eq(["app/models", "some/other/models"])
   end
 
   it "accepts and matches path names as well as strings" do
     models = models([Pathname.new("app/models")])
-    lambda { models.dirs }.should_not raise_error(TypeError)
-    models.dirs.should == [Pathname.new("app/models")]
+    expect { models.dirs }.not_to raise_error
+    expect(models.dirs).to eq([Pathname.new("app/models")])
   end
 
   it "preloads models by calling require_dependency" do
     models = models(["foo/bar/baz", "app/models", "some/other/models"])
-    Dir.stub(:glob).
+    allow(Dir).to receive(:glob).
         with(File.join("app/models", "**", "*.rb")).
         and_return(["app/models/user.rb", "app/models/address.rb"])
-    Dir.stub(:glob).
+    allow(Dir).to receive(:glob).
         with(File.join("some/other/models", "**", "*.rb")).
         and_return(["some/other/models/foo.rb"])
 
-    Kernel.should_receive(:require_dependency).with("app/models/user.rb")
-    Kernel.should_receive(:require_dependency).with("app/models/address.rb")
-    Kernel.should_receive(:require_dependency).with("some/other/models/foo.rb")
+    expect(Kernel).to receive(:require_dependency).with("app/models/user.rb")
+    expect(Kernel).to receive(:require_dependency).with("app/models/address.rb")
+    expect(Kernel).to receive(:require_dependency).with("some/other/models/foo.rb")
 
     models.preload_all
   end
@@ -42,8 +42,8 @@ describe ConsistencyFail::Models do
     model_b = double(:name => "cat")
     model_c = double(:name => "beach_ball")
 
-    ActiveRecord::Base.stub(:send).with(:descendants).and_return([model_a, model_b, model_c])
+    allow(ActiveRecord::Base).to receive(:send).with(:descendants).and_return([model_a, model_b, model_c])
 
-    models([]).all.should == [model_a, model_c, model_b]
+    expect(models([]).all).to eq([model_a, model_c, model_b])
   end
 end

--- a/spec/reporter_spec.rb
+++ b/spec/reporter_spec.rb
@@ -16,7 +16,7 @@ describe ConsistencyFail::Reporter do
     it "says everything's good" do
       subject.report_validates_uniqueness_problems([])
 
-      @fake_out.string.should =~ /Hooray!/
+      expect(@fake_out.string).to match(/Hooray!/)
     end
 
     it "shows a missing single-column index on a single model" do
@@ -24,7 +24,7 @@ describe ConsistencyFail::Reporter do
 
       subject.report_validates_uniqueness_problems(fake_ar_model("User", :table_name => "users") => missing_indexes)
 
-      @fake_out.string.should =~ /users\s+\(email\)/
+      expect(@fake_out.string).to match(/users\s+\(email\)/)
     end
 
     it "shows a missing multiple-column index on a single model" do
@@ -32,7 +32,7 @@ describe ConsistencyFail::Reporter do
 
       subject.report_validates_uniqueness_problems(fake_ar_model("Address", :table_name => "addresses") => missing_indexes)
 
-      @fake_out.string.should =~ /addresses\s+\(number, street, zip\)/
+      expect(@fake_out.string).to match(/addresses\s+\(number, street, zip\)/)
     end
 
     context "with problems on multiple models" do
@@ -46,12 +46,12 @@ describe ConsistencyFail::Reporter do
       end
 
       it "shows all problems" do
-        @fake_out.string.should =~ /users\s+\(email\)/m
-        @fake_out.string.should =~ /citizens\s+\(ssn\)/m
+        expect(@fake_out.string).to match(/users\s+\(email\)/m)
+        expect(@fake_out.string).to match(/citizens\s+\(ssn\)/m)
       end
 
       it "orders the models alphabetically" do
-        @fake_out.string.should =~ /citizens\s+\(ssn\).*users\s+\(email\)/m
+        expect(@fake_out.string).to match(/citizens\s+\(ssn\).*users\s+\(email\)/m)
       end
     end
   end
@@ -60,7 +60,7 @@ describe ConsistencyFail::Reporter do
     it "says everything's good" do
       subject.report_has_one_problems([])
 
-      @fake_out.string.should =~ /Hooray!/
+      expect(@fake_out.string).to match(/Hooray!/)
     end
 
     it "shows a missing single-column index on a single model" do
@@ -68,7 +68,7 @@ describe ConsistencyFail::Reporter do
 
       subject.report_has_one_problems(fake_ar_model("Friend", :table_name => "users") => missing_indexes)
 
-      @fake_out.string.should =~ /Friend\s+users\s+\(email\)/m
+      expect(@fake_out.string).to match(/Friend\s+users\s+\(email\)/m)
     end
   end
 
@@ -76,7 +76,7 @@ describe ConsistencyFail::Reporter do
     it "says everything's good" do
       subject.report_polymorphic_problems([])
 
-      @fake_out.string.should =~ /Hooray!/
+      expect(@fake_out.string).to match(/Hooray!/)
     end
 
     it "shows a missing compound index on a single model" do
@@ -84,7 +84,7 @@ describe ConsistencyFail::Reporter do
 
       subject.report_polymorphic_problems(fake_ar_model("Address", :table_name => "addresses") => missing_indexes)
 
-      @fake_out.string.should =~ /Address\s+addresses\s+\(addressable_type, addressable_id\)/m
+      expect(@fake_out.string).to match(/Address\s+addresses\s+\(addressable_type, addressable_id\)/m)
     end
   end
 end


### PR DESCRIPTION
This converts the test suite to use the new syntax and makes the tests compatible with rspec 3.1.0 (see https://github.com/trptcolin/consistency_fail/pull/21#issuecomment-56458554).

@trptcolin, please take a look
