### PR TITLE
Add `run` method to top-level module

### DIFF
--- a/bin/consistency_fail
+++ b/bin/consistency_fail
@@ -13,37 +13,7 @@ require File.join(Dir.pwd, "config", "environment")
 $:<< File.join(File.dirname(__FILE__), "..", "lib")
 require "consistency_fail"
 
-def problems(models, introspector)
-  models.map do |m|
-    [m, introspector.missing_indexes(m)]
-  end.reject do |m, indexes|
-    indexes.empty?
-  end
-end
-
-models = ConsistencyFail::Models.new($LOAD_PATH)
-models.preload_all
-
-reporter = ConsistencyFail::Reporter.new
-
-success = true
-
-introspector = ConsistencyFail::Introspectors::ValidatesUniquenessOf.new
-problems = problems(models.all, introspector)
-reporter.report_validates_uniqueness_problems(problems)
-success &&= problems.empty?
-
-introspector = ConsistencyFail::Introspectors::HasOne.new
-problems = problems(models.all, introspector)
-reporter.report_has_one_problems(problems)
-success &&= problems.empty?
-
-introspector = ConsistencyFail::Introspectors::Polymorphic.new
-problems = problems(models.all, introspector)
-reporter.report_polymorphic_problems(problems)
-success &&= problems.empty?
-
-if success
+if ConsistencyFail.run
   exit 0
 else
   exit 1

--- a/lib/consistency_fail.rb
+++ b/lib/consistency_fail.rb
@@ -4,3 +4,41 @@ require 'consistency_fail/introspectors/validates_uniqueness_of'
 require 'consistency_fail/introspectors/has_one'
 require 'consistency_fail/introspectors/polymorphic'
 require 'consistency_fail/reporter'
+
+module ConsistencyFail
+  def self.run
+    models = ConsistencyFail::Models.new($LOAD_PATH)
+    models.preload_all
+
+    reporter = ConsistencyFail::Reporter.new
+
+    success = true
+
+    introspector = ConsistencyFail::Introspectors::ValidatesUniquenessOf.new
+    problems = problems(models.all, introspector)
+    reporter.report_validates_uniqueness_problems(problems)
+    success &&= problems.empty?
+
+    introspector = ConsistencyFail::Introspectors::HasOne.new
+    problems = problems(models.all, introspector)
+    reporter.report_has_one_problems(problems)
+    success &&= problems.empty?
+
+    introspector = ConsistencyFail::Introspectors::Polymorphic.new
+    problems = problems(models.all, introspector)
+    reporter.report_polymorphic_problems(problems)
+    success &&= problems.empty?
+    
+    success
+  end
+  
+  private
+  
+  def self.problems(models, introspector)
+    models.map do |m|
+      [m, introspector.missing_indexes(m)]
+    end.reject do |m, indexes|
+      indexes.empty?
+    end
+  end
+end


### PR DESCRIPTION
This commit adds `ConsistencyFail.run`, which allows the entire check to
be run with one command. This allows the tool to be used from code, such
as in a Rake task or other testing suite. It also has the added benefit
of cleaning up the executable.