### PR TITLE
Check for emptiness in tests versus explicit empty array

### DIFF
--- a/spec/introspectors/has_one_spec.rb
+++ b/spec/introspectors/has_one_spec.rb
@@ -14,7 +14,7 @@ describe ConsistencyFail::Introspectors::HasOne do
     end
     
     it "finds none when they're already in place" do
-      expect(subject.missing_indexes(CorrectUser)).to eq([])
+      expect(subject.missing_indexes(CorrectUser)).to be_empty
     end
   end
   

--- a/spec/introspectors/polymorphic_spec.rb
+++ b/spec/introspectors/polymorphic_spec.rb
@@ -14,7 +14,7 @@ describe ConsistencyFail::Introspectors::Polymorphic do
     end
 
     it "finds none when they're already in place" do
-      expect(subject.missing_indexes(CorrectPost)).to eq([])
+      expect(subject.missing_indexes(CorrectPost)).to be_empty
     end
   end
   


### PR DESCRIPTION
In #24, I changed the tests to use `be_empty` vs `eq([])` to check for empty arrays. I neglected to update the tests in 2 spots. So this is just a fixup commit to correct those last 2 spots.