### PR TITLE
Allow consistency_fail to run into a rails plugin/engine

### DIFF
--- a/bin/consistency_fail
+++ b/bin/consistency_fail
@@ -1,19 +1,19 @@
 #!/usr/bin/env ruby
 
-rails_app_root = %w(spec/dummy test/dummy .).find { |path| File.exists?(File.expand_path(path, Dir.pwd)) }
+rails_app_root = %w(spec/dummy test/dummy).find { |path| File.exists?(File.expand_path(path, Dir.pwd)) } || ''
 
 begin
-  require File.join(Dir.pwd, rails_app_root, "config", "boot")
-rescue LoadError => e
+  require File.join(Dir.pwd, rails_app_root, 'config', 'boot')
+rescue LoadError
   puts "\nUh-oh! You must be in the root directory of a Rails project.\n"
   raise
 end
 
 require 'active_record'
-require File.join(Dir.pwd, rails_app_root, "config", "environment")
+require File.join(Dir.pwd, rails_app_root, 'config', 'environment')
 
 $:<< File.join(File.dirname(__FILE__), "..", "lib")
-require "consistency_fail"
+require 'consistency_fail'
 
 if ConsistencyFail.run
   exit 0

--- a/bin/consistency_fail
+++ b/bin/consistency_fail
@@ -1,14 +1,16 @@
 #!/usr/bin/env ruby
 
+rails_app_root = %w(spec/dummy test/dummy .).find { |path| File.exists?(File.expand_path(path, Dir.pwd)) }
+
 begin
-  require File.join(Dir.pwd, "config", "boot")
+  require File.join(Dir.pwd, rails_app_root, "config", "boot")
 rescue LoadError => e
   puts "\nUh-oh! You must be in the root directory of a Rails project.\n"
   raise
 end
 
 require 'active_record'
-require File.join(Dir.pwd, "config", "environment")
+require File.join(Dir.pwd, rails_app_root, "config", "environment")
 
 $:<< File.join(File.dirname(__FILE__), "..", "lib")
 require "consistency_fail"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,7 @@ require 'bundler/setup'
 
 Bundler.require(:default, :test)
 
-Dir['./spec/support/**/*.rb'].each { |file| require file }
+Dir['./spec/support/**/*.rb'].sort.each { |file| require file }
 
 RSpec.configure do |config|
   config.around do |example|


### PR DESCRIPTION
This 2 commits:
- resolve ptyagi16/guard-consistency_fail#2
- restore spec/support files require order (to run rspec tests)
