### PR TITLE
pass RAILS root directory as an argument

### DIFF
--- a/bin/consistency_fail
+++ b/bin/consistency_fail
@@ -1,17 +1,21 @@
 #!/usr/bin/env ruby
 
+base_dir = File.join(Dir.pwd, ARGV.first.to_s)
+puts "\nWarning! You are going out of current directory, ruby version may be wrong and some gems may be missing.\n" unless File.realpath(base_dir).start_with?(Dir.pwd)
+
 begin
-  require File.join(Dir.pwd, "config", "boot")
-rescue LoadError => e
+
+  require File.join(base_dir, 'config', 'boot')
+rescue LoadError
   puts "\nUh-oh! You must be in the root directory of a Rails project.\n"
   raise
 end
 
 require 'active_record'
-require File.join(Dir.pwd, "config", "environment")
+require File.join(base_dir, 'config', 'environment')
 
-$:<< File.join(File.dirname(__FILE__), "..", "lib")
-require "consistency_fail"
+$:<< File.join(File.dirname(__FILE__), '..', 'lib')
+require 'consistency_fail'
 
 if ConsistencyFail.run
   exit 0

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,7 @@ require 'bundler/setup'
 
 Bundler.require(:default, :test)
 
-Dir['./spec/support/**/*.rb'].each { |file| require file }
+Dir['./spec/support/**/*.rb'].sort.each { |file| require file }
 
 RSpec.configure do |config|
   config.around do |example|


### PR DESCRIPTION
- pass RAILS root directory as an argument according to suggestion in trptcolin/consistency_fail/pull/37 with default to current directory
- a warning is printed when the passed argument is out of the current application/gem
- restore spec/support files require order (to run rspec tests with Ruby 2.3)