### PR TITLE
Use `require` instead of `require_dependency`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,7 @@ source "https://rubygems.org"
 gemspec
 
 gem 'pry'
+
+group :test do
+  gem 'activesupport', '~> 5.0'
+end

--- a/lib/consistency_fail/models.rb
+++ b/lib/consistency_fail/models.rb
@@ -17,8 +17,9 @@ module ConsistencyFail
 
     def preload_all
       self.dirs.each do |d|
-        Dir.glob(File.join(d, "**", "*.rb")).each do |model_filename|
-          Kernel.require_dependency model_filename
+        ruby_files = Dir.glob(File.join(d, "**", "*.rb")).sort
+        ruby_files.each do |model_filename|
+          Kernel.require model_filename
         end
       end
     end

--- a/spec/index_spec.rb
+++ b/spec/index_spec.rb
@@ -1,13 +1,16 @@
+require_relative 'support/models/correct_address'
+require_relative 'support/models/wrong_address'
+
 describe ConsistencyFail::Index do
-  
+
   let(:index) do
     ConsistencyFail::Index.new(
-      CorrectAddress, 
-      CorrectAddress.table_name, 
+      CorrectAddress,
+      CorrectAddress.table_name,
       ["city", "state"]
     )
   end
-  
+
   describe "value objectiness" do
     it "holds onto model, table name, and columns" do
       expect(index.model).to eq(CorrectAddress)
@@ -24,12 +27,12 @@ describe ConsistencyFail::Index do
     end
   end
 
-  describe "equality test" do  
+  describe "equality test" do
     it "passes when everything matches" do
       expect(index).to eq(
         ConsistencyFail::Index.new(
-          "CorrectAddress".constantize, 
-          "correct_addresses", 
+          "CorrectAddress".constantize,
+          "correct_addresses",
           ["city", "state"]
         )
       )
@@ -38,8 +41,8 @@ describe ConsistencyFail::Index do
     it "fails when tables are different" do
       expect(index).not_to eq(
         ConsistencyFail::Index.new(
-          CorrectAttachment, 
-          CorrectAttachment.table_name, 
+          CorrectAttachment,
+          CorrectAttachment.table_name,
           ["attachable_id", "attachable_type"]
         )
       )
@@ -48,12 +51,12 @@ describe ConsistencyFail::Index do
     it "fails when columns are different" do
       expect(index).not_to eq(
         ConsistencyFail::Index.new(
-          CorrectAddress, 
-          CorrectAddress.table_name, 
+          CorrectAddress,
+          CorrectAddress.table_name,
           ["correct_user_id"]
         )
       )
     end
   end
-  
+
 end

--- a/spec/models_spec.rb
+++ b/spec/models_spec.rb
@@ -1,5 +1,5 @@
 describe ConsistencyFail::Models do
-  
+
   def models(load_path)
     ConsistencyFail::Models.new(load_path)
   end
@@ -19,7 +19,7 @@ describe ConsistencyFail::Models do
     expect(models.dirs).to eq([Pathname.new("app/models")])
   end
 
-  it "preloads models by calling require_dependency" do
+  it "preloads models" do
     models = models(["foo/bar/baz", "app/models", "some/other/models"])
     allow(Dir).to receive(:glob).
         with(File.join("app/models", "**", "*.rb")).
@@ -28,9 +28,9 @@ describe ConsistencyFail::Models do
         with(File.join("some/other/models", "**", "*.rb")).
         and_return(["some/other/models/foo.rb"])
 
-    expect(Kernel).to receive(:require_dependency).with("app/models/user.rb")
-    expect(Kernel).to receive(:require_dependency).with("app/models/address.rb")
-    expect(Kernel).to receive(:require_dependency).with("some/other/models/foo.rb")
+    expect(Kernel).to receive(:require).with("app/models/user.rb")
+    expect(Kernel).to receive(:require).with("app/models/address.rb")
+    expect(Kernel).to receive(:require).with("some/other/models/foo.rb")
 
     models.preload_all
   end
@@ -44,5 +44,9 @@ describe ConsistencyFail::Models do
 
     expect(models([]).all).to eq([model_a, model_c, model_b])
   end
-  
+
+  it "preloads models successfully" do
+    models = models([File.join(File.dirname(__FILE__), "support/models")])
+    expect {models.preload_all}.not_to raise_error
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,10 @@ require 'bundler/setup'
 
 Bundler.require(:default, :test)
 
-Dir['./spec/support/**/*.rb'].sort.each { |file| require file }
+require_relative 'support/active_record'
+require_relative 'support/schema'
+require 'active_support/dependencies'
+ActiveSupport::Dependencies.autoload_paths << './spec/support/models'
 
 RSpec.configure do |config|
   config.around do |example|

--- a/spec/support/models/blob.rb
+++ b/spec/support/models/blob.rb
@@ -1,0 +1,4 @@
+class Blob < ActiveRecord::Base
+  require_dependency 'blob/edible'
+  include Edible
+end

--- a/spec/support/models/blob/edible.rb
+++ b/spec/support/models/blob/edible.rb
@@ -1,0 +1,2 @@
+module Blob::Edible
+end

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -118,4 +118,8 @@ ActiveRecord::Schema.define(version: 0) do
   execute 'CREATE VIEW new_correct_people AS '\
           'SELECT * FROM correct_people '\
           'WHERE created_at = updated_at'
+
+  create_table :blob do |t|
+    t.timestamps
+  end
 end


### PR DESCRIPTION
So anyway, eventually I found that by `.reverse`'ing the results of the `Dir.glob` that finds the models to load, I could reproduce this. Looks like in particular `require_dependency 'activestorage/blob/analyzable` fails:

```
[1] pry(main)> require 'active_support/dependencies'
=> true
[2] pry(main)> require 'active_storage'
=> true
[3] pry(main)> ActiveSupport::Dependencies.autoload_paths << '/Users/colin/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activestorage-5.2.1/app/models'
=> ["/Users/colin/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activestorage-5.2.1/app/models"]
[4] pry(main)> require_dependency 'active_storage/blob/analyzable'
RuntimeError: Circular dependency detected while autoloading constant ActiveStorage::Blob::Analyzable
from /Users/colin/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activesupport-5.2.1/lib/active_support/dependencies.rb:504:in `load_missing_constant'
```

I'd like to avoid this class of issue in case it recurs in the future, and not just for ActiveStorage, so I'm making a couple of changes:

1. Use `require` instead of `require_dependency`. I have no idea why I was using `require_dependency` before - as far as I can tell it's mostly useful for reloading, and since the entire use case in `lib/consistency_fail/models.rb` is about *preloading*, this doesn't seem necessary. Maybe this was necessary back when I was using `ObjectSpace` as a terrible hack? Anyway, `require` it is.
2. `sort` the dependencies in any given `LOAD_PATH` directory before loading them in sequence, just so whatever issues happen along these lines in the future are more easily repeatable.